### PR TITLE
Update userdata.sh to install tokenizer with cargo package

### DIFF
--- a/lib/ec2Stack/userdata.sh
+++ b/lib/ec2Stack/userdata.sh
@@ -20,6 +20,7 @@ source /home/ubuntu/my_env/bin/activate
 
 # Install dependencies
 cd multi-modal-chatbot-with-advanced-rag/application
+sudo apt install -y cargo
 pip3 install -r requirements.txt
 
 # Create systemd service


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Streamlit daemon doesn't work on EC2 instance when deploying application. Caused by installing tokenizer, that is needed cargo package. Therefore, I need to update userscript to install cargo package before pip3 requirements install.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
