### PR TITLE
Fix: update python package name

### DIFF
--- a/lib/ec2Stack/userdata.sh
+++ b/lib/ec2Stack/userdata.sh
@@ -7,7 +7,7 @@ sudo apt-get update -y
 sudo apt-get install -y ec2-instance-connect
 sudo apt-get install -y git
 sudo apt-get install -y python3-pip
-sudo apt-get install -y python3.8-venv
+sudo apt-get install -y python3-venv
 
 # Clone repository
 cd /home/ubuntu


### PR DESCRIPTION

### Description of changes:

Update package `python3.8-venv` to `python3-venv` because installing python3.8-venv package returns an error below
```
$ sudo apt-get install -y python3.8-venv
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package python3.8-venv
E: Couldn't find any package by glob 'python3.8-venv'
E: Couldn't find any package by regex 'python3.8-venv'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
